### PR TITLE
fix: recursive loop on osx/win

### DIFF
--- a/exploration/2main.py
+++ b/exploration/2main.py
@@ -19,9 +19,10 @@ def mxrank(k) :
     multixrank_obj.write_ranking(ranking, path = "results/param_" + str(k))
 
 
-size = len(glob.glob("parameters/*.yml"))
-num_cpu = 14
-p = mp.Pool(processes=num_cpu)
-p.map(mxrank, [i for i in range(size)])    
+if __name__ == '__main__':
+    size = len(glob.glob("parameters/*.yml"))
+    num_cpu = 14
+    p = mp.Pool(processes=num_cpu)
+    p.map(mxrank, [i for i in range(size)])    
     
 


### PR DESCRIPTION
wrapped process spawner in if __main__ block to fix infinite loop on OS/X and Windows.
https://pythonforthelab.com/blog/differences-between-multiprocessing-windows-and-linux/